### PR TITLE
pam-ussh: Change IsAuthority -> IsUserAuthority

### DIFF
--- a/pam_ussh.go
+++ b/pam_ussh.go
@@ -124,7 +124,7 @@ func authenticate(w io.Writer, uid int, username, ca string, principals map[stri
 	}
 
 	c := &ssh.CertChecker{
-		IsAuthority: func(auth ssh.PublicKey) bool {
+		IsUserAuthority: func(auth ssh.PublicKey) bool {
 			return bytes.Equal(auth.Marshal(), caPubkey.Marshal())
 		},
 	}


### PR DESCRIPTION
In `x/ssh/crypto` a breaking change was introduced by pmoody in commit
527d12e53572562de9fd348d50e1ee4096803cec.  This implements the needed
fix within `pam_ussh.go` to support the upstream go change.

This resolves #5.